### PR TITLE
[B28-Parent-Child-location-finders]

### DIFF
--- a/backend/controllers/LocationController.js
+++ b/backend/controllers/LocationController.js
@@ -1,88 +1,129 @@
 import {
-    createLocation,
-    findLocation,
-    findUniverseLocations,
-    searchLocations,
-    updateLocation,
-    destroyLocation,
+  createLocation,
+  updateLocation,
+  findLocation,
+  findChildLocations,
+  findAncestorLocations,
+  findUniverseLocations,
+  searchLocations,
+  destroyLocation
 } from "../services/LocationService.js";
 import { NotFoundException } from "../errors.js";
 
 async function getLocation(req, res) {
-    if (req.params.id === undefined)
-      res.status(400).send({ message: "ID must be defined" });
-    try {
-      const location = await findLocation(req.params.id);
-      res.status(200).json(location);
-    } catch (e) {
-      return res.status(400).json({ message: e.message });
-    }
-}
+  if (req.params.id === undefined) {
+    res.status(400).send({ message: "ID must be defined" });
+    return;
+  }
+  try {
+    const location = await findLocation(req.params.id);
+    res.status(200).json(location);
+  } catch (e) {
+    return res.status(400).json({ message: e.message });
+  }
+};
 
 async function getUniverseLocations(req, res) {
-    if (req.params.universeID === undefined) {
-        res.status(400).send({ message: "universeID must be defined" });
-    }
-    try {
-      const locations = await findUniverseLocations(req.params.universeID, parseInt(req.query.limit), parseInt(req.query.offset));
-      res.status(200).json(locations);
-    } catch (e) {
-      return res.status(400).json({ message: e.message });
-    }
-}
+  if (req.params.universeID === undefined) {
+    res.status(400).send({ message: "universeID must be defined" });
+    return;
+  }
+  try {
+    const locations = await findUniverseLocations(req.params.universeID, parseInt(req.query.limit), parseInt(req.query.offset));
+    res.status(200).json(locations);
+  } catch (e) {
+    return res.status(400).json({ message: e.message });
+  }
+};
+
+async function getChildLocations(req, res) {
+  if (req.params.id === undefined) {
+    res.status(400).send({ message: "id must be defined" });
+    return;
+  }
+  try {
+    const locations = await findChildLocations(req.params.id);
+    res.status(200).json(locations);
+  } catch (e) {
+    return res.status(400).json({ message: e.message });
+  }
+};
+
+async function getAncestorLocations(req, res) {
+  if (req.params.id === undefined) {
+    res.status(400).send({ message: "id must be defined" });
+    return;
+  }
+  try {
+    const locations = await findAncestorLocations(req.params.id);
+    res.status(200).json(locations);
+  } catch (e) {
+    return res.status(400).json({ message: e.message });
+  }
+};
 
 async function getSearchedLocations(req, res) {
-    if (req.params.universeID === undefined) {
-        res.status(400).send({ message: "universeID must be defined" });
-    }
-    try {
-      let q = req.query.q;
-      let limit = parseInt(req.query.limit);
-      let offset = parseInt(req.query.offset);
-      const locations = await searchLocations(req.params.universeID, q, limit, offset);
-      res.status(200).json(locations);
-    } catch (e) {
-      return res.status(400).json({ message: e.message });
-    }
-}
+  if (req.params.universeID === undefined) {
+    res.status(400).send({ message: "universeID must be defined" });
+    return;
+  }
+  try {
+    let q = req.query.q;
+    let limit = parseInt(req.query.limit);
+    let offset = parseInt(req.query.offset);
+    const locations = await searchLocations(req.params.universeID, q, limit, offset);
+    res.status(200).json(locations);
+  } catch (e) {
+    return res.status(400).json({ message: e.message });
+  }
+};
 
 async function postLocation(req, res) {
-    try {
-        let parentLocation = req.body.locationID ? req.body.locationID : null;
-      const createdLocation = await createLocation(
-        req.body.name,
-        req.body.description,
-        req.body.universeID,
-        parentLocation
-      );
-      res.status(201).json(createdLocation);
-    } catch (e) {
-      res.status(400).send({ message: e.message });
-    }
-}
+  try {
+    let parentLocation = req.body.locationID ? req.body.locationID : null;
+    const createdLocation = await createLocation(
+      req.body.name,
+      req.body.description,
+      req.body.universeID,
+      parentLocation
+    );
+    res.status(201).json(createdLocation);
+  } catch (e) {
+    res.status(400).send({ message: e.message });
+  }
+};
 
 async function deleteLocation(req, res) {
-    try {
-      await destroyLocation(req.params.id);
-      res.status(200).send();
-    } catch (e) {
-      res.status(400).send({ message: e.message });
-    }
-}
+  try {
+    await destroyLocation(req.params.id);
+    res.status(200).send();
+  } catch (e) {
+    res.status(400).send({ message: e.message });
+  }
+};
 
 async function patchLocation(req, res) {
-    try {
-      const id = req.params.id;
-      await updateLocation(id, req.body);
-      res.status(200).send();
-    } catch (e) {
-      if (e instanceof NotFoundException) {
-        res.status(404);
-      } else {
-        res.status(400);
-      }
-      res.send({ message: e.message });
+  try {
+    const id = req.params.id;
+    await updateLocation(id, req.body);
+    res.status(200).send();
+  } catch (e) {
+    if (e instanceof NotFoundException) {
+      res.status(404);
+    } else {
+      res.status(400);
     }
+    res.send({ message: e.message });
   }
+};
 
-  export { getLocation, getUniverseLocations, getSearchedLocations, postLocation, deleteLocation, patchLocation };
+export {
+  getLocation,
+  getUniverseLocations,
+  getChildLocations,
+  getAncestorLocations,
+  getSearchedLocations,
+  postLocation,
+  deleteLocation,
+  patchLocation
+};

--- a/backend/routes/LocationRouter.js
+++ b/backend/routes/LocationRouter.js
@@ -1,4 +1,12 @@
-import { postLocation, patchLocation, getLocation, getUniverseLocations, getSearchedLocations, deleteLocation }
+import { getLocation,
+    getUniverseLocations,
+    getChildLocations,
+    getAncestorLocations,
+    getSearchedLocations,
+    postLocation,
+    deleteLocation,
+    patchLocation
+}
 from "../controllers/LocationController.js";
 import express from "express";
 
@@ -8,6 +16,8 @@ LocationRouter.use(express.json());
 LocationRouter.route('/locations').post(postLocation);
 LocationRouter.route('/locations/:id').get(getLocation);
 LocationRouter.route('/locations/universe/:universeID').get(getUniverseLocations);
+LocationRouter.route('/locations/children/:id').get(getChildLocations);
+LocationRouter.route('/locations/ancestors/:id').get(getAncestorLocations);
 LocationRouter.route('/locations/search/:universeID').get(getSearchedLocations);
 LocationRouter.route('/locations/:id').delete(deleteLocation);
 LocationRouter.route('/locations/:id').patch(patchLocation);

--- a/backend/services/EventService.js
+++ b/backend/services/EventService.js
@@ -1,6 +1,6 @@
 import { db } from '../models/index.js';
 import { NotFoundException } from "../errors.js";
-import { Sequelize, QueryTypes } from "sequelize";
+import { Sequelize } from "sequelize";
 import { currentDateTimetoIsoString } from "./utils.js";
 import { createContent } from "./ContentService.js";
 
@@ -112,7 +112,7 @@ async function findTimelineEvents(timelineID, limit, offset) {
         LIMIT :limit
         OFFSET :offset;`,
         {
-            type: QueryTypes.SELECT,
+            type: db.sequelize.QueryTypes.SELECT,
             replacements: {
                 timelineID: timelineID,
                 limit: findLimit,
@@ -121,7 +121,6 @@ async function findTimelineEvents(timelineID, limit, offset) {
         });
         return events;
     } catch(err) {
-        console.log(err.message);
         throw new NotFoundException("Events for this timeline were not found");
     }
 }


### PR DESCRIPTION
[added] findChildLocations function in LocationService
[added] findParentChainLocations function in LocationService
[fixed] Removed unnecessary console log in EventService
[added] getChildLocations function in LocationController
[added] getParentChainLocations function in LocationController
[fixed] Added proper returns after sending response in LocationController functions
[refactored] Renamed findParentChainLocations function to findAncestorLocations in LocationService
[refactored] Renamed getParentChainLocations function to getAncestorLocations in LocationService
[added] New routes for getAncestorLocations and getChildLocations functions in LocationRouter
[fixed] Used QueryTypes in findAncestorLocations function in LocationService
[changed] Used db QueryTypes in EventService
[changed] Excluded location with selected 'id' from query results in findAncestorLocations