### PR TITLE
[F40-category-management-popup]

### DIFF
--- a/frontend/src/components/LbUniverseNav.vue
+++ b/frontend/src/components/LbUniverseNav.vue
@@ -13,7 +13,7 @@
       <icon icon="lb-plus-square"></icon>
       <span class="lb-universe-nav__button-text">Create Element</span>
     </button>
-    <button class="lb-universe-nav__button">
+    <button class="lb-universe-nav__button" @click="openCategoriesPopup">
       <icon icon="lb-folder"></icon>
       <span class="lb-universe-nav__button-text">Categories</span>
     </button>
@@ -29,12 +29,16 @@
 </template>
 
 <script>
-import { mapGetters } from 'vuex';
+import { mapGetters, mapMutations } from 'vuex';
 
 export default {
     name: 'LbUniverseNav',
     computed: {
-      ...mapGetters('universe', ['universeName', 'universeID'])
+      ...mapGetters('universe', ['universeName', 'universeID']),
+      ...mapGetters('popups', ['isCategoriesPopupOpen'])
+    },
+    methods: {
+      ...mapMutations('popups', ['openCategoriesPopup']),
     }
 };
 </script>

--- a/frontend/src/pages/UniversePage.vue
+++ b/frontend/src/pages/UniversePage.vue
@@ -1,15 +1,20 @@
 <template>
   <div class="universe-page">
     {{ `${universeID} : ${universeName}`}}
+    <categories-popup></categories-popup>
   </div>
 </template>
 
 <script>
 import { mapGetters, mapMutations, mapActions } from 'vuex';
+import CategoriesPopup from '../popups/CategoriesPopup.vue';
 import { getUniverse } from '../httpLayers/universe.http.js';
 
 export default {
     name: 'UniversePage',
+    components: {
+      CategoriesPopup
+    },
     computed: {
       ...mapGetters('universe', ['universeName', 'universeID'])
     },

--- a/frontend/src/popups/CategoriesPopup.vue
+++ b/frontend/src/popups/CategoriesPopup.vue
@@ -1,0 +1,251 @@
+<template>
+  <lb-popup-box :isOpen="isCategoriesPopupOpen" title="Categories in current universe" @close="close">
+    <div class="categories-popup">
+        <div class="categories-popup__form">
+          <lb-input name="Name" :value="categoryName" @update:value="setName" :error="categoryNameError" :maxLength="45"></lb-input>
+          <div class="categories-popup__buttons" :class="setButtonsClass">
+            <lb-button
+                v-if="selectedCategory === null"
+                :size="1.2"
+                variant="positive"
+                icon="lb-plus"
+                @click="addCategory"
+                :disabled="disableFormButtons">Add new category</lb-button>
+            <lb-button
+                v-if="selectedCategory !== null"
+                :size="1.2"
+                variant="outline"
+                @click="cancelEdit">Cancel</lb-button>
+            <lb-button
+                v-if="selectedCategory !== null"
+                :size="1.2"
+                icon="lb-edit"
+                @click="renameCategory"
+                :disabled="disableFormButtons">Rename</lb-button>
+          </div>
+        </div>
+        <div class="categories-popup__categories-table">
+          <table class="categories-table">
+            <thead>
+              <tr class="categories-table__row categories-table__row--header">
+                <th class="categories-table__cell categories-table__cell--header">Category</th>
+                <th class="categories-table__cell categories-table__cell--header">Elements</th>
+                <th class="categories-table__cell categories-table__cell--header"></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="categories-table__row" :class="isRowEdited(cat.id)" v-for="cat in categoriesList" :key="cat.id">
+                <td class="categories-table__cell">{{ cat.name }}</td>
+                <td class="categories-table__cell">{{ cat.elementCount }}</td>
+                <td class="categories-table__cell">
+                  <div class="categories-table__buttons" v-if="isCategoryMutable(cat.id)">
+                    <lb-button :size="1.2" icon="lb-edit" @click="editCategory(cat.id)"></lb-button>
+                    <lb-button
+                        :size="1.2"
+                        icon="lb-trash"
+                        variant="negative"
+                        @click="deleteCategory(cat.id)"
+                        :disabled="this.selectedCategory == cat.id"></lb-button>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+    </div>
+  </lb-popup-box>
+</template>
+
+<script>
+import { mapGetters, mapMutations } from 'vuex';
+import LbInput from '../components/LbInput.vue';
+
+export default {
+    name: 'CategoriesPopup',
+    components: {
+      LbInput,
+    },
+    props: {
+    },
+    emits: ["onResult"],
+    data() {
+      return {
+          categoryName: '',
+          categoryNameError: '',
+          loading: false,
+          selectedCategory: null,
+          categoriesList: [
+            {
+              id: 'Characters',
+              name: 'Characters',
+              elementCount: 7
+            },
+            {
+              id: 'Locations',
+              name: 'Locations',
+              elementCount: 3
+            },
+            {
+              id: 'Events',
+              name: 'Events',
+              elementCount: 3
+            },
+            {
+              id: 1,
+              name: 'Creatures',
+              elementCount: 8
+            },
+            {
+              id: 2,
+              name: 'Religons',
+              elementCount: 2
+            },
+          ]
+      };
+    },
+    computed: {
+      ...mapGetters('popups', ['isCategoriesPopupOpen']),
+      ...mapGetters('universe', ['universeCategories']),
+      setButtonsClass() {
+        if(this.selectedCategory !== null) {
+          return 'categories-popup__buttons--rename-mode';
+        }
+        return '';
+      },
+      disableFormButtons() {
+        if(this.categoryName.length < 1 || this.categoryNameError.length > 0) {
+          return true;
+        }
+        return false;
+      },
+      isCategoryNameValid() {
+        return this.categoryName.length > 0 && !this.categoriesList.find(cat => {return cat.name === this.categoryName})
+      },
+    },
+    methods: {
+      ...mapMutations('popups', ['closeCategoriesPopup']),
+      close() {
+        this.closeCategoriesPopup();
+      },
+      setName(newValue) {
+        this.categoryNameError = '';
+        this.categoryName = newValue;
+      },
+      isCategoryMutable(categoryID) {
+        return !['Locations', 'Characters', 'Events'].includes(categoryID);
+      },
+      isRowEdited(id) {
+        if (this.selectedCategory == id) {
+          return 'categories-table__row--edited';
+        } else {
+          return '';
+        }
+      },
+      editCategory(id) {
+        if (this.selectedCategory == id) {
+          this.selectedCategory = null;
+          this.categoryName = '';
+        } else {
+          this.selectedCategory = id;
+          this.categoryName = this.categoriesList.find(cat => cat.id == id).name;
+        }
+      },
+      cancelEdit() {
+        this.selectedCategory = null;
+        this.categoryName = '';
+      },
+      addCategory() {
+        if( this.isCategoryNameValid ) {
+          this.categoriesList.push({id: 3, name: this.categoryName, elementCount: 0});
+          this.categoryName = '';
+        } else {
+          this.categoryNameError = 'Category with that name already exists';
+        }
+      },
+      renameCategory() {
+        if( this.isCategoryNameValid ) {
+          this.categoriesList.find(cat => cat.id == this.selectedCategory).name = this.categoryName;
+          this.cancelEdit();
+        } else {
+          this.categoryNameError = 'Category with that name already exists';
+        }
+      },
+      deleteCategory(id) {
+        if(confirm('Do you really want to delete this category? You will lose all elements belonging in this category. It cannot be undone!')) {
+          this.categoriesList = this.categoriesList.filter(cat => cat.id !== id);
+        }
+      }
+    }
+};
+</script>
+
+<style lang="less">
+@import '../common.less';
+
+.categories-popup {
+  display: flex;
+  flex-direction: column;
+  width: 800px;
+
+  .categories-popup__form {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 1em;
+
+    .categories-popup__buttons {
+      display: flex;
+      justify-content: flex-end;
+      margin-top: 1em;
+
+      &--rename-mode {
+        justify-content: space-between;
+      }
+    }
+  }
+
+  .categories-popup__categories-table {
+    display: flex;
+    flex-direction: column;
+    max-height: 50vh;
+    overflow-y: auto;
+
+    .categories-table {
+      border-spacing: 0;
+
+      .categories-table__row {
+        background-color: @element-color;
+        padding: 0.5em;
+
+        &--header {
+          background-color: @secondary-color;
+          font-size: 1.2rem;
+        }
+
+        &--edited {
+          box-shadow: inset 0px 3px 15px rgba(0, 0, 0, 0.3);
+        }
+
+        .categories-table__cell {
+          border-bottom: 1px solid @dark-text-color;
+          padding: 0.5em;
+          font-weight: 600;
+          color: @dark-text-color;
+
+          &--header {
+            text-align: start;
+              color: @light-text-color;
+              font-weight: 700;
+          }
+
+          .categories-table__buttons {
+            display: flex;
+            justify-content: flex-end;
+            gap: 5px;
+          }
+        }
+      }
+    }
+  }
+}
+
+</style>

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1,11 +1,13 @@
 import { createStore } from 'vuex';
 import notificationsModule from './notifications.store';
 import universeModule from './universe.store';
+import popupModule from './popup.store';
 
 const store = createStore({
   modules: {
     notifications: notificationsModule,
-    universe: universeModule
+    universe: universeModule,
+    popups: popupModule
   },
   state: {
     userID: null,

--- a/frontend/src/store/popup.store.js
+++ b/frontend/src/store/popup.store.js
@@ -1,0 +1,23 @@
+const popupModule = {
+    namespaced: true,
+    state() {
+        return {
+            isCategoriesPopupOpen: false,
+        };
+    },
+    getters: {
+        isCategoriesPopupOpen(state) {
+            return state.isCategoriesPopupOpen;
+        },
+    },
+    mutations: {
+        openCategoriesPopup(state) {
+            state.isCategoriesPopupOpen = true;
+        },
+        closeCategoriesPopup(state) {
+            state.isCategoriesPopupOpen = false;
+        },
+    },
+};
+
+export default popupModule;


### PR DESCRIPTION
[added] Basic dummy CategoriesPopup component
[added] Popup store module for managing popups
[added] Use of CategoriesPopup in UniversePage
[changed] Open CategoriesPopup on click in LbUniverseNav
[added] Basic layout with mock data in CategoriesPopup
[added] Methods for edit and remove category in CategoriesPopup
[added] Styling for category table in CategoriesPopup
Added mock functions to add new category and edit existing one
Added validation for input and buttons in CategoriesPopup
Added styling for row of edited category

closes #150 